### PR TITLE
Resolve problema no javascript do readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Para executar o bot em um site você precisa inserir o seguinte Javascript na su
 ```js
 <!-- Start of Rocket.Chat Livechat Script -->
 <script type="text/javascript">
-    // !!! Mudar para o seu host AQUI !!!
-    host = 'http://localhost:3000';
-    // !!! ^^^^^^^^^^^^^^^^^^^^^^^^^^ !!!
+// !!! Mudar para o seu host AQUI !!!
+host = 'http://localhost:3000';
+// !!! ^^^^^^^^^^^^^^^^^^^^^^^^^^ !!!
 (function(w, d, s, u) {
     w.RocketChat = function(c) { w.RocketChat._.push(c) }; w.RocketChat._ = []; w.RocketChat.url = u;
     var h = d.getElementsByTagName(s)[0], j = d.createElement(s);


### PR DESCRIPTION
A forma como o readme está hoje, com o host sendo definido dentro da função anônima, não está criando a `div` do rocket.chat.

Isso é resolvido na alteração proposta removendo a definição do host do escopo da função anônima e declarando-o antes dela ser chamada.