### PR TITLE
Treinando antes de subir o Telegram

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Configure todas as informações necessárias no docker-compose para integrar o 
 Para executar somente o serviço do bot para o Telegram, utilize o seguinte comando:
 
 ```
+sudo docker-compose run --rm bot make train
 sudo docker-compose up telegram_bot
 ```
 

--- a/README.md
+++ b/README.md
@@ -86,10 +86,17 @@ Configure todas as informações necessárias no docker-compose para integrar o 
 - WEBHOOK_URL={link do ngrok}/webhooks/telegram/webhook
 ```
 
-Para executar somente o serviço do bot para o Telegram, utilize os seguintes comandos:
+Para executar somente o serviço do bot para o Telegram, utilize o seguinte comando:
 
-```
+Se ainda não tiver treinado seu bot execute antes:
+
+```sh
 sudo docker-compose run --rm bot make train
+```
+
+Depois execute o bot no telegram:
+
+```sh
 sudo docker-compose up telegram_bot
 ```
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Configure todas as informações necessárias no docker-compose para integrar o 
 - WEBHOOK_URL={link do ngrok}/webhooks/telegram/webhook
 ```
 
-Para executar somente o serviço do bot para o Telegram, utilize o seguinte comando:
+Para executar somente o serviço do bot para o Telegram, utilize os seguintes comandos:
 
 ```
 sudo docker-compose run --rm bot make train


### PR DESCRIPTION
Como não achei o documento de contribuição no git, estou colaborando da forma que acho que ficará mais clara.
Adicionei o comando de treinar o bot antes de subir o mesmo no telegram, pois quando você tenta subir para o telegram sem treina-lo antes, ocorrem alguns erros, como:
`Failed to load model metadata from '/bot/models/nlu/current/metadata.json'. [Errno 2] No such file or directory: 'models/nlu/current/metadata.json'`

Deste modo, alguém que está apenas interessado em testar a integração com o telegram, não terá erros

