### PR TITLE
Remove first run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,3 @@
-first-run:
-	docker-compose up -d rocketchat
-	make build-bot
-	docker-compose run --rm bot make config-rocket
-	docker-compose up bot
-
 build-bot:
 	./docker/build-base.sh
 	make train

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build-bot:
 	make train
 
 train:
-	docker build . -f docker/coach.Dockerfile -t botcoach:latest
+	docker build . -f docker/coach.Dockerfile -t lappis/coach:boilerplate
 	docker-compose build bot
 
 run-rocketchat:

--- a/README.md
+++ b/README.md
@@ -25,18 +25,11 @@ avaliação das conversas dos usuários e do boilerplate.
 
 ## Bot
 
-**Atenção**: Para funcionamento inicial das imagens docker citadas aqui, como "bot", "coach" e "requirements", é
-importante que em sua primeira execução deste repositório, seja executado:
-
-```sh
-sudo make first-run
-```
 
 Este script foi configurado para construir as imagens genéricas necessárias para execução deste ambiente.
 Caso seu projeto utilize este boilerplate e vá realizar uma integração contínua ou similar, é interessante
-criar um repositório para as imagens e substitua os nomes das imagens "bot", "coach" e "requirements" pelas
-suas respectivas novas imagens, por exemplo "<organização>/bot" em repositório público, não sendo mais necessário
-então a execução do script "first-run".
+criar um repositório para as imagens e substitua os nomes das imagens "lappis/bot", "lappis/coach" e "lappis/botrequirements" pelas
+suas respectivas novas imagens, por exemplo "<organização>/bot" em repositório público.
 
 ### RocketChat
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,8 @@ services:
 
   # ================================= Bot =====================================
   bot:
+    image: lappis/bot:boilerplate
     container_name: bot_rocketchat
-    image: bot
     build:
       context: .
       dockerfile: ./docker/bot.Dockerfile

--- a/docker/actions.Dockerfile
+++ b/docker/actions.Dockerfile
@@ -1,4 +1,4 @@
-FROM requirements:latest
+FROM lappis/botrequirements:boilerplate
 
 ADD ./bot/actions/actions.py /bot/actions/actions.py
 ADD ./bot/Makefile /bot/Makefile

--- a/docker/bot.Dockerfile
+++ b/docker/bot.Dockerfile
@@ -1,5 +1,5 @@
-FROM botcoach:latest as coach
-FROM requirements:latest
+FROM lappis/coach:boilerplate as coach
+FROM lappis/botrequirements:boilerplate
 
 
 COPY ./bot /bot

--- a/docker/build-base.sh
+++ b/docker/build-base.sh
@@ -5,7 +5,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-base_image=requirements:latest
+base_image=lappis/botrequirements:boilerplate
 
 # Build base image
 docker build . -f docker/requirements.Dockerfile -t $base_image

--- a/docker/coach.Dockerfile
+++ b/docker/coach.Dockerfile
@@ -1,4 +1,4 @@
-FROM requirements:latest
+FROM lappis/botrequirements:boilerplate
 
 COPY ./coach /coach
 COPY ./scripts /scripts

--- a/docker/notebooks.Dockerfile
+++ b/docker/notebooks.Dockerfile
@@ -1,4 +1,4 @@
-FROM requirements:latest
+FROM lappis/botrequirements:boilerplate
 
 RUN apt-get install -y graphviz libgraphviz-dev pkg-config
 

--- a/docs/README-en.md
+++ b/docs/README-en.md
@@ -25,21 +25,10 @@ evaluation of user conversations and boilerplate.
 
 ## Bot
 
-**Attention**: For initial operation of the docker images quoted here, such as "bot", "coach" and "requirements", is
-important that in its first execution of this repository, be executed:
-
-```sh
-docker-compose up -d rocketchat
-
-make first-run
-# or 
-sudo make first-run
-```
 
 This script has been configured to build the generic images needed to run this environment.
 If your project uses this boilerplate and goes to perform continuous or similar integration, it is interesting
-create a repository for the images and replace the names of the "bot", "coach" and "requirements" their respective new images, for example "<organization>/bot" in a public repository, no longer needed
-then run the "first-run" script.
+create a repository for the images and replace the names of the "bot", "coach" and "requirements" their respective new images, for example "<organization>/bot" in a public repository.
 
 ### RocketChat
 


### PR DESCRIPTION
Publiquei imagens com os requirements, coach e bot do boilerplate no repositório do lappis no dockerhub, agora é possível remover o comando make first-run