### PR TITLE
corrigindo o nome do pacote a ser instalado no dockerfile do kibana

### DIFF
--- a/docker/kibana.Dockerfile
+++ b/docker/kibana.Dockerfile
@@ -6,7 +6,7 @@ COPY analytics/dashboards.json analytics/dashboards.json
 USER root
 
 RUN yum -y update
-RUN yum -y install yum utils
+RUN yum -y install yum-utils
 RUN yum -y groupinstall development
 RUN yum -y install https://centos7.iuscommunity.org/ius-release.rpm
 RUN yum -y install python36u


### PR DESCRIPTION
## Antes dessa correção, o seguinte erro era apresentado:

Transaction check error:
  file /usr/bin/easy_install-3.6 from install of python36u-setuptools-39.0.1-1.ius.el7.noarch conflicts with file from package python3-setuptools-39.2.0-10.el7.noarch
.....
ERROR: Service 'kibana' failed to build: The command '/bin/sh -c yum -y install python36u-pip' returned a non-zero code: 1
make: *** [run-analytics] Error 1
