### PR TITLE
Devel: Telegram, fix compose, make e docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ run-webchat:
 	sensible-browser --no-sandbox modules/webchat/index.html
 
 run-telegram:
-	docker-compose run -d --rm --service-ports bot make telegram
+	docker-compose run -d --rm --service-ports bot_telegram make telegram
 
 run-notebooks:
 	docker-compose up -d notebooks

--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ Após realizar o [tutorial](/docs/setup_telegram.md) de exportação de todas va
 
 **Antes de seguir adiante. Importante:** As variáveis de ambiente são necessárias para o correto funcionamento do bot, por isso não esqueça de exportá-las.
 
+Edite o arquivo **credentials.yml** e descomente as linhas referentes ao telegram:
+
+```sh
+telegram:
+ access_token: ${TELEGRAM_TOKEN}
+ verify: ${TELEGRAM_BOT_USERNAME}
+ webhook_url: ${TELEGRAM_WEBHOOK}
+```
+
 Se ainda não tiver treinado seu bot execute antes:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Para a visualização dos dados da interação entre o usuário e o chatbot nós
 * Para uma **configuração rápida** execute o seguinte comando:
 
 ```sh
-sudo make buil-analytics
+sudo make build-analytics
 ```
 
 O comando acima só precisa ser executado apenas 1 vez e já vai deixar toda a infra de `analytics` pronta para o uso.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,20 +37,6 @@ services:
       - ./bot/actions:/bot/actions
     command: sh -c "make run-actions"
 
-  # ============================ Telegram Bot =================================
-  # Specific Rasa bot integrated with Telegram.
-  bot-telegram:
-      build:
-        context: .
-        dockerfile: ./docker/bot.Dockerfile
-      env_file:
-        - env/bot-telegram.env
-      ports:
-        - 5005:5005
-      depends_on:
-        - actions
-      command: sh -c "make telegram"
-
   # ============================ WebChat Bot =================================
   # Specific Rasa bot integrated with WebChat.
   bot-webchat:
@@ -133,7 +119,7 @@ services:
         - actions
       volumes:
         - ./bot:/bot
-      command: sh -c "make run-telegram"
+      command: sh -c "make telegram"
 
   # =============================== Notebooks =================================
   # Rasa lab to enhance hyperparameters.


### PR DESCRIPTION
## Descrição

haviam duas entradas sobre o telegram no docker-compose
o comando make run-telegram não estava funcionando
docs sobre o telegram não falava na edição do credentials.yml
doc do comando build-analytics, escrito errado.
