### PR TITLE
Change release url on kibana dockerfile

### DIFF
--- a/docker/kibana.Dockerfile
+++ b/docker/kibana.Dockerfile
@@ -8,7 +8,7 @@ USER root
 RUN yum -y update
 RUN yum -y install yum-utils
 RUN yum -y groupinstall development
-RUN yum -y install https://centos7.iuscommunity.org/ius-release.rpm
+RUN yum -y install https://repo.ius.io/ius-release-el7.rpm
 RUN yum -y install python36u
 RUN yum -y install python36u-pip
 


### PR DESCRIPTION
# Descrição
## Problema

![image](https://user-images.githubusercontent.com/4125846/93689981-08f6d580-faaa-11ea-903b-f1b6b107aee2.png)

Não era possível subir o serviço do  Analytics. O problema era no paso de instalação.

## Solução

Troquei o mirror que estava sendo usado para insalação
Agora é possível subir entrar no kibana `localhost:5601`
Ainda não testei se os dados estão sendo integrados 
