### PR TITLE
Arrumar comando make run-x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ run-actions:
 	docker-compose run --rm --service-ports bot make actions
 
 run-x:
-	docker-compose run --rm --service-ports bot make x
+	docker-compose run --rm --service-ports x make x
 
 run-webchat:
 	$(info )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,8 @@ services:
       - ./bot/:/bot/
     ports:
       - 5002:5002
+    env_file:
+      - env/rasax.env
     depends_on:
       - actions
     command: sh -c "make x"

--- a/docker/bot.Dockerfile
+++ b/docker/bot.Dockerfile
@@ -4,4 +4,6 @@ WORKDIR /bot
 COPY ./bot /bot
 COPY ./modules /modules
 
+ENV GIT_PYTHON_REFRESH quiet
+
 RUN find . | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf

--- a/docker/bot.Dockerfile
+++ b/docker/bot.Dockerfile
@@ -4,6 +4,4 @@ WORKDIR /bot
 COPY ./bot /bot
 COPY ./modules /modules
 
-ENV GIT_PYTHON_REFRESH quiet
-
 RUN find . | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf

--- a/env/rasax.env
+++ b/env/rasax.env
@@ -1,0 +1,1 @@
+GIT_PYTHON_REFRESH=quiet


### PR DESCRIPTION
## Descrição

O comando make run-x, subia o container do bot, que exporta somente a porta 5006. Mudei para que o comando subisse o container x, que exporta a porta 5002, utilizada pelo rasa x.
Além disso, foi adicionado a variável de ambiente do git necessária para rodar o rasa x.
