### PR TITLE
Add HAProxy as loadbalancer for ws

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,17 +59,39 @@ services:
 
   # ============================ WebChat Bot =================================
   # Specific Rasa bot integrated with WebChat.
-  bot-webchat:
+  bot-webchat-core1:
       build:
         context: .
         dockerfile: ./docker/bot.Dockerfile
       volumes:
         - ./bot/:/bot/
-      ports:
-        - 5007:5007
       depends_on:
         - actions
       command: sh -c "make webchat"
+
+  bot-webchat-core2:
+      build:
+        context: .
+        dockerfile: ./docker/bot.Dockerfile
+      volumes:
+        - ./bot/:/bot/
+      depends_on:
+        - actions
+      command: sh -c "make webchat"
+
+  # =========================== Loadbalancer =================================
+  # HAProxy used as loadbalancer for more than 1 instance of bot-webchat
+  # Use case for load balacing websockets
+  bot-webchat:
+    image: haproxy:2.3
+    volumes:
+      - "./modules/haproxy/:/usr/local/etc/haproxy:ro"
+    ports:
+      - 5007:5007
+      - 32700:32700
+    depends_on:
+      - bot-webchat-core1
+      - bot-webchat-core2
 
   # ============================ WebChat Bot =================================
   # Specific Rasa bot integrated with WebChat.

--- a/modules/haproxy/haproxy.cfg
+++ b/modules/haproxy/haproxy.cfg
@@ -1,0 +1,52 @@
+defaults
+  mode http
+  log global
+  option httplog
+  option  http-server-close
+  option  dontlognull
+  option  redispatch
+  option  contstats
+  retries 3
+  backlog 10000
+  timeout client          10s
+  timeout connect         5s
+  timeout server          10s
+	timeout tunnel			  3600s
+  timeout http-keep-alive  1s
+  timeout http-request    15s
+  timeout queue           30s
+  timeout tarpit          60s
+  default-server inter 3s rise 2 fall 3
+  option forwardfor
+
+frontend http_webchat
+  bind :5007 name http
+  timeout connect 240s
+  default_backend rasa_webchat_core
+
+	acl is_websocket path_beg /socket.io
+  acl is_websocket hdr(Upgrade) -i WebSocket
+  acl is_websocket hdr_beg(Host) -i ws
+
+	use_backend rasa_ws if is_websocket
+
+backend rasa_webchat_core
+  balance roundrobin
+
+  server websrv1 bot-webchat-core1:5007 maxconn 10 weight 10 cookie websrv1 check
+  server websrv2 bot-webchat-core2:5007 maxconn 10 weight 10 cookie websrv2 check
+
+backend rasa_ws
+  balance roundrobin 
+  http-check expect status 200
+  cookie io prefix indirect nocache
+
+  server websrv1 bot-webchat-core1:5007 maxconn 10 weight 10 cookie websrv1 check
+  server websrv2 bot-webchat-core2:5007 maxconn 10 weight 10 cookie websrv2 check
+
+listen stats
+    bind :32700
+    stats enable
+    stats uri /
+    stats hide-version
+    stats auth admin:admin


### PR DESCRIPTION
## Descrição

HAProxy configurado com 2 instancias do core.

Ao rodar `make run-webchat` vc pode acompanhar as conexoes em `localhost:32700`, as credenciais sao `admin:admin`.

As portas do core sao fechadas externamente e todas as conexoes passam pelo HAProxy, na mesma porta

## Resolve (Issues)

#196 


CC @BrunaNayara @arthurTemporim 