### PR TITLE
Pip/python upgrade

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.8, 3.7]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.7]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/bot/Makefile
+++ b/bot/Makefile
@@ -1,8 +1,6 @@
 .PHONY: all clean actions
 
 ## FLAGS:
-# TODO: This is a hotfix while RASA don't solve dependencies issues.
-PIP_FLAGS = --use-deprecated=legacy-resolver 
 LOG_LEVEL = -v
 RASA_ENDPOINTS = --endpoints endpoints.yml
 RASA_CREDENTIALS = --credentials credentials.yml
@@ -12,8 +10,8 @@ clean:
 
 install:
 	pip install --upgrade pip 						&& \
-	pip install $(PIP_FLAGS) -r requirements.txt	&& \
-	pip install $(PIP_FLAGS) -r x-requirements.txt
+	pip install -r requirements.txt	&& \
+	pip install -r x-requirements.txt
 
 # RASA X
 x:

--- a/docker/consumer.Dockerfile
+++ b/docker/consumer.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.8.9-slim-buster
 
 RUN python -m pip install --upgrade pip
 

--- a/docker/requirements.Dockerfile
+++ b/docker/requirements.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.8.9-slim-buster
 
 ARG BOT_DIR=./bot
 

--- a/docs/Tutoriais/tutorial-pipeline-de-bot.md
+++ b/docs/Tutoriais/tutorial-pipeline-de-bot.md
@@ -13,7 +13,7 @@ O primeiro passo para configuração é definir uma imagem base a ser utilizada 
 Para definir uma imagem global é necessário utilizar a configuração abaixo:
 
 ```yml
-image: python:3.6-slim
+image: python:3.8.9-slim-buster
 
 test style:
   stage: test style


### PR DESCRIPTION
## Descrição

Atualização das versões 3.6 e 3.7 do Python para 3.8 (novas versões do rasa funcionam melhor no 3.8). Essas imagens vem com a nova versão do pip que não terá problemas com o resolver novo.

## Resolve (Issues)

Closes #202 