### PR TITLE
Melhoria na dockerização do projeto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,14 +8,18 @@ clean:
 stop:
 	docker-compose stop
 
+
+############################## DOCKERHUB ##############################
+dchub-requirements:
+	docker push arthurtemporim/boilerplate-requirements
+
 ############################## BOILERPLATE ##############################
 first-run:
 	make build
 	make train
-	make run-shell
+	make shell
 
 build:
-	make build-requirements
 	make build-coach
 	make build-bot
 
@@ -23,7 +27,7 @@ build-requirements:
 	docker build . \
 		--no-cache \
 		-f docker/requirements.Dockerfile \
-		-t botrequirements
+		-t arthurtemporim/boilerplate-requirements
 
 build-bot:
 	docker-compose build \
@@ -34,7 +38,7 @@ build-coach:
 		--no-cache coach
 
 build-analytics:
-	make run-analytics
+	make analytics
 	make config-elastic
 	# This line should be removed ASAP
 	sleep 10

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ docker ps
 Se tudo der certo, você conseguirá ver uma tabela com dois contêineres de nomes `rasa-ptbr-boilerplate_bot-webchat` e 
 `rasa-ptbr-boilerplate_actions` na coluna IMAGE.
 
-Para iniciar uma conversa com o chatbot, execute o comando `make run-shell`, espere o comando rodar e divirta-se!
+Para iniciar uma conversa com o chatbot, execute o comando `make shell`, espere o comando rodar e divirta-se!
 
 
 ## Introdução
@@ -98,7 +98,7 @@ make train
 Para executar o bot no terminal execute:
 
 ```sh
-make run-shell
+make shell
 ```
 
 ### Executando o bot no Telegram
@@ -110,7 +110,7 @@ Após realizar o [tutorial](/docs/setup_telegram.md) de exportação de todas va
 Depois execute o bot no telegram:
 
 ```sh
-make run-telegram
+make telegram
 ```
 
 ### Analytics
@@ -169,7 +169,7 @@ Por último basta treinar o bot novamente, e a informação será armazenada na 
 Levante o container `notebooks`
 
 ```sh
-make run-notebooks
+make notebooks
 ```
 
 Acesse o notebook em `localhost:8888`

--- a/docker/actions.Dockerfile
+++ b/docker/actions.Dockerfile
@@ -1,4 +1,4 @@
-FROM botrequirements
+FROM arthurtemporim/boilerplate-requirements:latest
 
 COPY ./bot/actions/ /bot/actions/
 COPY ./bot/Makefile /bot/Makefile

--- a/docker/bot.Dockerfile
+++ b/docker/bot.Dockerfile
@@ -1,4 +1,4 @@
-FROM botrequirements
+FROM arthurtemporim/boilerplate-requirements:latest
 
 WORKDIR /bot
 COPY ./bot /bot

--- a/docker/consumer.Dockerfile
+++ b/docker/consumer.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.8.9-slim-buster
 
 RUN python -m pip install --upgrade pip
 

--- a/docker/notebooks.Dockerfile
+++ b/docker/notebooks.Dockerfile
@@ -1,4 +1,4 @@
-FROM botrequirements
+FROM arthurtemporim/boilerplate-requirements:latest
 
 RUN apt-get update && apt-get install -y graphviz libgraphviz-dev pkg-config
 

--- a/docker/requirements.Dockerfile
+++ b/docker/requirements.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.8.9-slim-buster 
 
 ARG BOT_DIR=./bot
 
@@ -9,6 +9,7 @@ COPY $BOT_DIR/Makefile /tmp
 RUN apt-get update                                                             && \
     apt-get install -y gcc make build-essential git                            && \
     make  -C /tmp install                                                      && \
+    rasa telemetry disable                                                     && \
     python -c "import nltk; nltk.download(['stopwords', 'rslp', 'punkt']);"    && \
     find . | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf               && \
     apt-get clean                                                              && \

--- a/docs/Tutoriais/tutorial-pipeline-de-bot.md
+++ b/docs/Tutoriais/tutorial-pipeline-de-bot.md
@@ -13,7 +13,7 @@ O primeiro passo para configuração é definir uma imagem base a ser utilizada 
 Para definir uma imagem global é necessário utilizar a configuração abaixo:
 
 ```yml
-image: python:3.6-slim
+image: python:3.8.9-slim-buster
 
 test style:
   stage: test style


### PR DESCRIPTION
## Descrição

Atualmente o projeto demora para ser buildado com o comando `make first-run` por esses fatores:
1. Faz o **download** dos pacotes do rasa, linux e dependências **INTERNET**
2. Faz a extração e instalação dos pacotes baixados **PROCESSAMENTO**
3. Finaliza com o container pronto no computador **DISCO**

Os pacotes do RASA utilizam cerca de `2GB`de armazenamento e tem que ser baixados sempre. Mas o processamento de extração e instalação pode ser evitado caso uma imagem prévia seja feita e publicada no dockerhub.

Neste PR contém a atualização do projeto para baixar a imagem:
* [boilerplate-requirements](https://hub.docker.com/repository/docker/arthurtemporim/boilerplate-requirements/general)

Dessa forma o uso de **armazenamento** e **internet** vão permanecer os mesmos, mas o uso de **processamento** será poupado pois esta instalação é préviamente feita, evitando perda de tempo.
